### PR TITLE
Add --save-feedback option to automate saving feedback PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ classroom that match the configured basename.
 
 Passing `--save-feedback` will save a PDF of the "Files changed" tab for each
 student in the marking repository. Files will be stored in a `feedback/`
-subdirectory with the name of each file being `<github_username>.pdf`.
+subdirectory with the name of each file being `<PR title>.pdf`.
 
 Taking these screenshots requires the use of a browser to render the pages and
 so [`selenium`](https://www.selenium.dev/) is used to automate the process of:

--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ student in the marking repository. Files will be stored in a `feedback/`
 subdirectory with the name of each file being `<github_username>.pdf`.
 
 Taking these screenshots requires the use of a browser to render the pages and
-so [`selenium`](https://www.selenium.dev/) (`pip install selenium`) is used to
-automate the process of: navigating to the correct web page, waiting for it to
-load and printing to a PDF. At present only Google Chrome/Chromium (via
+so [`selenium`](https://www.selenium.dev/) is used to automate the process of:
+navigating to the correct web page, waiting for it to load and printing to a PDF.
+At present only Google Chrome/Chromium (via
 [`chromedriver`](https://chromedriver.chromium.org/home)) is supported.
 
 Each time `--save-feedback` is passed a fresh browser instance is created

--- a/README.md
+++ b/README.md
@@ -184,6 +184,30 @@ classroom-tool --unwatch
 This unsubscribes the logged-in user from all repositories in the configured
 classroom that match the configured basename.
 
+### Saving feedback on pull requests
+
+Passing `--save-feedback` will save a PDF of the "Files changed" tab for each
+student in the marking repository. Files will be stored in a `feedback/`
+subdirectory with the name of each file being `<github_username>.pdf`.
+
+Taking these screenshots requires the use of a browser to render the pages and
+so [`selenium`](https://www.selenium.dev/) (`pip install selenium`) is used to
+automate the process of: navigating to the correct web page, waiting for it to
+load and printing to a PDF. At present only Google Chrome/Chromium (via
+[`chromedriver`](https://chromedriver.chromium.org/home)) is supported.
+
+Each time `--save-feedback` is passed a fresh browser instance is created
+without existing cookies. In order for the browser to be able to access the
+pull requests it needs to first be logged in to GitHub. To make this work the
+browser will initially load the GitHub login page where the `classroom-tool`
+user can log in to their GitHub account. Once this is done, hitting Enter in the
+terminal will trigger `classroom-tool` to begin saving the PDFs.
+
+Note that the "Files changed" tab on GitHub automatically collapses the diffs
+from files if the diffs are too large. This means that any comments on the code
+are not visible. To avoid this assignments should therefore encourage students
+to not put all of their code into a single large file.
+
 ## Anonymising the repository
 
 Remapping the repository names to university identity numbers is not enough to

--- a/scripts/classroom-tool
+++ b/scripts/classroom-tool
@@ -170,7 +170,7 @@ def login_to_github(browser):
     input("Once you have logged in please press Enter to continue:")
 
 
-def save_pull_request_as_pdf(browser, repo, github_username, pr_number):
+def save_pull_request_as_pdf(browser, repo, pr):
     """Open the 'Files changed' tab of a pull request and save the page as a PDF.
 
     Parameters
@@ -179,18 +179,16 @@ def save_pull_request_as_pdf(browser, repo, github_username, pr_number):
         The Chrome/Chromium instance.
     repo : github.Repository.Repository
         The marking repository where the feedback is stored.
-    github_username : str
-        The GitHub username of the student.
-    pr_number : int
-        Pull request identifier (used in the URL).
+    pr : github.PullRequest.PullRequest
+        The pull request to save.
     """
-    filename = f"feedback/{github_username}.pdf"
+    filename = f"feedback/{pr.title}.pdf"
     if os.path.exists(filename):
         logging.info(f"{filename} already exists, skipping")
         return
 
-    logging.info(f"Saving pull request for {github_username} to {filename}")
-    url = f"https://github.com/{repo.full_name}/pull/{pr_number}/files"
+    logging.info(f"Saving pull request #{pr.number} to {filename}")
+    url = f"https://github.com/{repo.full_name}/pull/{pr.number}/files"
     browser.get(url)
     time.sleep(5)  # wait for the page to fully load
     save_current_page_as_pdf(browser, filename)
@@ -421,11 +419,8 @@ if args.save_feedback:
     browser = launch_browser()
     login_to_github(browser)
 
-    roster = pd.read_csv(config("students", "roster"))
     marking_repo = gh_org().get_repo(config("github", "marking-repo"))
-    prs_by_github_username = {pr.title: pr for pr in marking_repo.get_pulls()}
-    for gh in roster["github_username"]:
-        pr = prs_by_github_username[gh]
-        save_pull_request_as_pdf(browser, marking_repo, gh, pr.number)
+    for pr in marking_repo.get_pulls():
+        save_pull_request_as_pdf(browser, marking_repo, pr)
 
     browser.quit()

--- a/scripts/classroom-tool
+++ b/scripts/classroom-tool
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
 import os
+import sys
 import github  # Install pygithub
 import git     # Install gitpython
 from argparse import ArgumentParser
 import datetime
+import base64
+import json
 from configparser import ConfigParser
 import logging
 import pandas as pd
 from functools import cache
 import time
+from selenium import webdriver
 
 
 class ClassroomToolError(Exception):
@@ -46,6 +50,8 @@ parser.add_argument("--pull-requests", action="store_true",
                     help="Create marking pull requests.")
 parser.add_argument("--unwatch", action="store_true",
                     help="Unwatch all repositories that match the basename")
+parser.add_argument("--save-feedback", action="store_true",
+                    help="Save PDFs of the feedback left on the pull requests.")
 
 args = parser.parse_args()
 
@@ -145,6 +151,76 @@ def extra_time(roster):
     else:
         logging.info("No extra time column found, assuming no extra time.")
         return [datetime.timedelta(minutes=0) for r in roster.index]
+
+
+def launch_browser():
+    return webdriver.Chrome("chromedriver")
+
+
+def login_to_github(browser):
+    """Launch the GitHub login page and wait until the user has logged in.
+
+    Parameters
+    ----------
+    browser : selenium.webdriver.chrome.webdriver.WebDriver
+        The Chrome/Chromium instance.
+    """
+    logging.info("Loading GitHub login page")
+    browser.get('https://github.com/login')
+    input("Once you have logged in please press Enter to continue:")
+
+
+def save_pull_request_as_pdf(browser, repo, github_username, pr_number):
+    """Open the 'Files changed' tab of a pull request and save the page as a PDF.
+
+    Parameters
+    ----------
+    browser : selenium.webdriver.chrome.webdriver.WebDriver
+        The Chrome/Chromium instance.
+    repo : github.Repository.Repository
+        The marking repository where the feedback is stored.
+    github_username : str
+        The GitHub username of the student.
+    pr_number : int
+        Pull request identifier (used in the URL).
+    """
+    filename = f"feedback/{github_username}.pdf"
+    if os.path.exists(filename):
+        logging.info(f"{filename} already exists, skipping")
+        return
+
+    logging.info(f"Saving pull request for {github_username} to {filename}")
+    url = f"https://github.com/{repo.full_name}/pull/{pr_number}/files"
+    browser.get(url)
+    time.sleep(5)  # wait for the page to fully load
+    save_current_page_as_pdf(browser, filename)
+
+
+def save_current_page_as_pdf(browser, filename):
+    """Save the currently opened page as a PDF (in A2 format).
+
+    Parameters
+    ----------
+    browser : selenium.webdriver.chrome.webdriver.WebDriver
+        The Chrome/Chromium instance.
+    filename : str
+        The name of the PDF file to write to.
+    """
+    url = (browser.command_executor._url
+           + f"/session/{browser.session_id}/chromium/send_command_and_get_result")
+    params = {
+        "landscape": False,
+        "displayHeaderFooter": False,
+        "printBackground": True,
+        # A2 size
+        "paperWidth": 16.5,
+        "paperHeight": 23.4,
+    }
+    body = json.dumps({"cmd": "Page.printToPDF", "params": params})
+    response = browser.command_executor._request("POST", url, body)
+
+    with open(filename, "wb") as f:
+        f.write(base64.b64decode(response["value"]["data"]))
 
 
 if args.fetch:
@@ -336,3 +412,20 @@ if args.create_report:
     else:
         raise ClassroomToolError(
             "No repositories to report. Did you forget to --create-branches.")
+
+if args.save_feedback:
+    if not os.path.exists("feedback"):
+        logging.info("Creating 'feedback' directory as it does not already exist")
+        os.mkdir("feedback")
+
+    browser = launch_browser()
+    login_to_github(browser)
+
+    roster = pd.read_csv(config("students", "roster"))
+    marking_repo = gh_org().get_repo(config("github", "marking-repo"))
+    prs_by_github_username = {pr.title: pr for pr in marking_repo.get_pulls()}
+    for gh in roster["github_username"]:
+        pr = prs_by_github_username[gh]
+        save_pull_request_as_pdf(browser, marking_repo, gh, pr.number)
+
+    browser.quit()

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     pygithub
     gitpython
     pandas
+    selenium
 scripts = scripts/classroom-tool
 
 [options.packages.find]


### PR DESCRIPTION
Some productive procrastination. I hope this is useful.

This works on my (Linux) laptop with Chromium but it should hopefully work for Chrome too. Adding other browsers like Safari would mean I'd need to figure out how to call their "print to PDF" functionality.